### PR TITLE
feat: adjust spanish as the default language for the theme

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -13,20 +13,20 @@ languageCode = 'en-US'
 languageDirection = 'ltr'
 languageName = "English"
 weight = 2
-# baseURL = "/en/"
+baseURL = "/en/"
 
 [languages.en.taxonomies]
 category = "categories"
 tag = "tags"
 
 [languages.es]
-contentDir = 'content/es'
+contentDir = 'content/'
 disabled = false
 languageCode = 'es'
 languageDirection = 'ltr'
 languageName = "Español"
 weight = 1
-# baseURL = "/"
+baseURL = "/"
 
 [languages.es.taxonomies]
 category = "categorias"


### PR DESCRIPTION
Adapting theme to bulsara needs, Hugo statics compilation will generate the spanish version of the web with the root content, as it currently is.